### PR TITLE
Fix(AnswerContainder.js) FeedCard.js로 넘기는 props 분리

### DIFF
--- a/src/components/answerFeedCard/FeedCard.js
+++ b/src/components/answerFeedCard/FeedCard.js
@@ -12,8 +12,7 @@ import clickedUp from '../../assets/images/clicked_up.svg';
 import clickedDown from '../../assets/images/clicked_down.svg';
 import PopOverMenu from 'components/modal/PopOverMenu';
 
-export default function Feedcard(question) {
-  console.log(question);
+export default function Feedcard({ question, answerer }) {
   const [answer, setAnswer] = useState('');
   const [isCompleted, setIsCompleted] = useState(false);
   const [isSubmit, setIsSubmited] = useState(false);
@@ -62,9 +61,14 @@ export default function Feedcard(question) {
   const handelUpdateEditAnswer = () => setEditAnswer(false);
 
   const handleSubmitEditAnswer = async (questionId, text, boolean) => {
-    const { answer } = await getQuestions(questionId);
-    setEditAnswer(true);
-    handlePatchAnswer(answer.id, { content: text, isRejected: boolean });
+    if (!question.answer?.id) {
+      const { answer } = await getQuestions(questionId);
+      setEditAnswer(true);
+      handlePatchAnswer(answer.id, { content: text, isRejected: boolean });
+    } else {
+      setEditAnswer(true);
+      handlePatchAnswer(question.answer.id, { content: text, isRejected: boolean });
+    }
   };
   const handletoggleLike = () => {
     if (liked === false) {
@@ -91,7 +95,6 @@ export default function Feedcard(question) {
   };
 
   return (
-
     <S.FcContainer>
       {isMenuOpen && <PopOverMenu id={question?.id} answerId={question?.answer?.id} />}
 
@@ -112,11 +115,11 @@ export default function Feedcard(question) {
       </S.FcQuestionWrapper>
       <S.FcAnswerContainer>
         <S.FcProfileWrapper>
-          <S.FcProfile $url={question.imageSource} alt="프로필" />
+          <S.FcProfile $url={answerer.imageSource} alt="프로필" />
         </S.FcProfileWrapper>
         <S.FcAnswerWrapper>
           <S.FcAnswerer>
-            {question?.name}
+            {answerer?.name}
             {question?.answer ? (
               <S.DisplayTime>{timeForToday(question.answer?.createdAt)}</S.DisplayTime>
             ) : null}

--- a/src/components/answerFeedCard/FeedCard.js
+++ b/src/components/answerFeedCard/FeedCard.js
@@ -24,7 +24,8 @@ export default function Feedcard({ question, answerer }) {
   const [dislikeCount, setDislikeCount] = useState(question.dislike);
   const [isMenuOpen, setMenuOpen] = useState(false);
 
-  const handleCreateAnswer = async (questionId, answerData) => {
+  //답변 생성하고 post 이후 되돌아온 값을 setter 에 넣어 input 태그의 밸류 값인 answer를 변경
+  const CreateAnswerForSubmit = async (questionId, answerData) => {
     try {
       const result = await createAnswer(questionId, answerData);
       setAnswer(result.content);
@@ -33,7 +34,8 @@ export default function Feedcard({ question, answerer }) {
     }
   };
 
-  const handlePatchAnswer = async (answerId, answerData) => {
+  // 답변 수정 이후  수정 결과를 setter에 넣어 제출된 답변 상태 변경
+  const PatchAnswerForSubmitEditAnswer = async (answerId, answerData) => {
     try {
       const result = await updateAnswersPartial(answerId, answerData);
       setAnswer(result.content);
@@ -41,35 +43,42 @@ export default function Feedcard({ question, answerer }) {
       console.log(error);
     }
   };
-
+  // input 태그에서 답변 입력을 하지 않거나 수정할 때 수정내용이 비었을 시 완료버튼 활성화 토글
   const handleChangeAnswer = (e) => {
     setAnswer(e.target.value);
     answer ? setIsCompleted(true) : setIsCompleted(false);
     if (e.target.value === '') return setIsCompleted(false);
   };
-
+  // 답변 제출 버튼  온클릭시
   const handleSubmitAnswer = (questionId, text, boolean) => {
     if (text) {
       setIsSubmited(true);
-      handleCreateAnswer(questionId, { content: text, isRejected: boolean });
+      CreateAnswerForSubmit(questionId, { content: text, isRejected: boolean });
     }
   };
+
+  // 제출된 답변을 답변 수정 상황으로 바꾸는 함수
   const handleUpdateAnswer = () => {
     setUpdate(!isUpdate);
     setAnswer(question?.answer?.content);
   };
+
+  // 한 번 이상 답변 수정 이후  또 다시 수정 상황으로 돌아가는 함수
   const handelUpdateEditAnswer = () => setEditAnswer(false);
 
+  // 수정완료 버튼! 이미 답변이 있는 질문이면 question 안에 answer.id가 있기 때문에 바로 사용 가능하지만,
+  // 아직 답변이 달리지 않은 질문에 답변하고 바로 수정할 경우에는 이미 렌더링 된 question엔 아직 답변이 null 값이기에 해당 질문을 가져와서 답변 아이디 이용
   const handleSubmitEditAnswer = async (questionId, text, boolean) => {
     if (!question.answer?.id) {
       const { answer } = await getQuestions(questionId);
       setEditAnswer(true);
-      handlePatchAnswer(answer.id, { content: text, isRejected: boolean });
+      PatchAnswerForSubmitEditAnswer(answer.id, { content: text, isRejected: boolean });
     } else {
       setEditAnswer(true);
-      handlePatchAnswer(question.answer.id, { content: text, isRejected: boolean });
+      PatchAnswerForSubmitEditAnswer(question.answer.id, { content: text, isRejected: boolean });
     }
   };
+
   const handletoggleLike = () => {
     if (liked === false) {
       setLiked(!liked);
@@ -120,7 +129,7 @@ export default function Feedcard({ question, answerer }) {
         <S.FcAnswerWrapper>
           <S.FcAnswerer>
             {answerer?.name}
-            {question?.answer ? (
+            {question?.answer && isSubmit ? (
               <S.DisplayTime>{timeForToday(question.answer?.createdAt)}</S.DisplayTime>
             ) : null}
           </S.FcAnswerer>

--- a/src/components/answerFeedCard/FeedCard.js
+++ b/src/components/answerFeedCard/FeedCard.js
@@ -104,6 +104,10 @@ export default function Feedcard({ question, answerer }) {
   };
 
   return (
+    // isUpdate로 조건부 스타일링 안하면 SubmitedAnswer 컴포넌트와 FcAnswerInput 컴포넌트가 중첩됨
+    // question?.answer는 이미 답변이 있는 피드카드를 답변완료상태로 렌더링 하기 위해서 사용
+    // isSubmit은 아직 답변이 달리지 않은 피드카드를 답변작성완료 했을 때, 답변완료상태로 렌더링하기 위해서 사용
+
     <S.FcContainer>
       {isMenuOpen && <PopOverMenu id={question?.id} answerId={question?.answer?.id} />}
 

--- a/src/components/answerFeedCard/FeedCardStyled.js
+++ b/src/components/answerFeedCard/FeedCardStyled.js
@@ -243,6 +243,7 @@ export const SubmitedAnswer = styled.div`
   font: var(--body3-regular);
   line-height: 2.2rem;
   display: ${({ $isUpdate }) => ($isUpdate ? 'none' : 'block')};
+  flex-wrap: nowrap;
 `;
 
 export const DisplayTime = styled.span`

--- a/src/pages/answer/AnswerContainer.js
+++ b/src/pages/answer/AnswerContainer.js
@@ -13,7 +13,7 @@ import FACEBOOK from 'assets/images/ShareIcon_FACEBOOK.svg';
 export default function Answer({ userId }) {
   const [questionList, setQuestionList] = useState([]);
   const [isOpenModal, setOpenModal] = useState(false);
-  const [answererProfile, setAnswerProfile] = useState({});
+  const [answererProfile, setAnswererProfile] = useState({});
 
   const handleRenderSubjectsOnQ = async (id) => {
     try {
@@ -28,8 +28,9 @@ export default function Answer({ userId }) {
   const handleRenderSubjectProfile = async (id) => {
     try {
       const result = await getSubject(id);
+      const { name, imageSource } = result;
 
-      setAnswerProfile(result);
+      setAnswererProfile({ ...answererProfile, name, imageSource });
     } catch (error) {
       console.log(error);
     }
@@ -87,7 +88,9 @@ export default function Answer({ userId }) {
           ) : (
             <>
               {questionList.map((question) => {
-                return <FeedCard key={question.id} {...question} {...answererProfile} />;
+                return (
+                  <FeedCard key={question.id} question={question} answerer={answererProfile} />
+                );
               })}
             </>
           )}

--- a/src/pages/answer/AnswerContainer.js
+++ b/src/pages/answer/AnswerContainer.js
@@ -1,5 +1,5 @@
 import * as S from '../post/PostStyle';
-
+import { DeleteButton, ButtonWrapper } from './AnswerStyle.js';
 import { useState, useEffect } from 'react';
 import ClipBoardCopyMessage from 'components/ClipBoardCopyMessage';
 import FeedCard from 'components/answerFeedCard/FeedCard.js';
@@ -12,7 +12,6 @@ import FACEBOOK from 'assets/images/ShareIcon_FACEBOOK.svg';
 
 export default function Answer({ userId }) {
   const [questionList, setQuestionList] = useState([]);
-  const [isOpenModal, setOpenModal] = useState(false);
   const [answererProfile, setAnswererProfile] = useState({});
 
   const handleRenderSubjectsOnQ = async (id) => {
@@ -34,10 +33,6 @@ export default function Answer({ userId }) {
     } catch (error) {
       console.log(error);
     }
-  };
-
-  const handleClickButton = () => {
-    setOpenModal(!isOpenModal);
   };
 
   const handleAllDeleteQuestionList = async (id) => {
@@ -71,11 +66,9 @@ export default function Answer({ userId }) {
           <S.LinkIcon src={FACEBOOK} alt="페이스북링크_아이콘"></S.LinkIcon>
         </S.LinkContainer>
 
-        <S.ButtonWrapper>
-          <S.DeleteButton onClick={() => handleAllDeleteQuestionList(userId)}>
-            삭제하기
-          </S.DeleteButton>
-        </S.ButtonWrapper>
+        <ButtonWrapper>
+          <DeleteButton onClick={() => handleAllDeleteQuestionList(userId)}>삭제하기</DeleteButton>
+        </ButtonWrapper>
         <S.FeedContainer>
           <S.Info>
             <S.IconMessage />

--- a/src/pages/answer/AnswerStyle.js
+++ b/src/pages/answer/AnswerStyle.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const DeleteButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 0.8rem;
+  width: 100px;
+  height: 35px;
+  border-radius: 200px;
+  background: var(--brown40);
+  box-shadow: var(--shadow2pt);
+  color: var(--gray10);
+  font-family: Actor;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 25px;
+  cursor: pointer;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 71.6rem;
+  flex-direction: row-reverse;
+`;

--- a/src/pages/post/PostStyle.js
+++ b/src/pages/post/PostStyle.js
@@ -115,30 +115,3 @@ export const CreateQuestionButton = styled.button`
   line-height: 25px;
   cursor: pointer;
 `;
-
-export const DeleteButton = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: nowrap;
-  gap: 0.8rem;
-  width: 100px;
-  height: 35px;
-  border-radius: 200px;
-  background: var(--brown40);
-  box-shadow: var(--shadow2pt);
-  color: var(--gray10);
-  font-family: Actor;
-  font-size: 1.5rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 25px;
-  cursor: pointer;
-`;
-
-export const ButtonWrapper = styled.div`
-  display: flex;
-  width: 100%;
-  max-width: 71.6rem;
-  flex-direction: row-reverse;
-`;


### PR DESCRIPTION
Fix(styled-components):input 태그 nowrap 설정 및 주석으로 함수 설명 작성
Feat(AnswerStyle.js): 답변 페이지 스타일 분리 및 post페이지와 구분되는 고유 컴포넌트 추가


배너에 있는 큰 사진은 서브젝트 아이디에 맞게 렌더링하도록 만들어야될 것 같아요. 

제 생각에는... 답변 페이지에서는 좋아요 및 싫어요의 count만 실시간으로 표현하고 기능은 안넣는게 좋을 것 같아요
본인이 본인 게시물 추천 및 비추 할 수 있는 다른 웹페이지들도 물론 있기는 하지만, 굳이 관리해야되는 
함수 혹은 state를 늘릴 필요는 없다고 생각합니다.  


